### PR TITLE
Add costs to information extracted when building services for Fedex

### DIFF
--- a/lib/Shipment/FedEx.pm
+++ b/lib/Shipment/FedEx.pm
@@ -331,6 +331,10 @@ sub _build_services {
             id => 'YOUR_PACKAGING',
             name => 'Customer Supplied',
           ),
+          cost => Data::Currency->new(
+            $service->get_RatedShipmentDetails->[0]->get_ShipmentRateDetail->get_TotalNetCharge->get_Amount,
+            $service->get_RatedShipmentDetails->[0]->get_ShipmentRateDetail->get_TotalNetCharge->get_Currency
+          ),
         );
     }
     $services{ground} = $services{'FEDEX_GROUND'} || $services{'GROUND_HOME_DELIVERY'} || $services{'INTERNATIONAL_GROUND'} || Shipment::Service->new();


### PR DESCRIPTION
Add costs to the returned data when building the service list for FedEx.  Rather then having to do two requests to FedEx one to get the available service list, and a second for the actual costs we can just grab the data from the first request.
