### PR TITLE
Use total weight rather then 1 in pull of service list.

### DIFF
--- a/lib/Shipment/FedEx.pm
+++ b/lib/Shipment/FedEx.pm
@@ -268,6 +268,9 @@ sub _build_services {
   push @from_streetlines, $self->from_address()->address1;
   push @from_streetlines, $self->from_address()->address2 if $self->from_address()->address2;
 
+  my $total_weight;
+  $total_weight += $_->weight for @{ $self->packages };
+
   try {
     $response = $interface->getRates( 
       { 
@@ -314,7 +317,7 @@ sub _build_services {
           PackageDetail => 'INDIVIDUAL_PACKAGES',
           RequestedPackageLineItems =>  { 
             Weight => {
-              Value => 1,
+              Value => $total_weight,
               Units => $units_type_map{$self->weight_unit} || $self->weight_unit,
             }, 
           },


### PR DESCRIPTION
If we're going to pull the prices for FedEx out of the available service list, it makes sense to use the total weight, so the price is accurate.
